### PR TITLE
Add listing ID parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Skeleton project for parsing [otodom.pl](https://www.otodom.pl) and notifying ab
 - `evaluation/` – modules for location and ChatGPT evaluation.
 - `notifications/` – Telegram bot notifier.
 - `scheduler/` – APScheduler based periodic tasks.
+- Price history is stored for each listing and updated when prices change.
+- Listing ID is parsed from the listing page and stored for reference.
 
 ## Usage
 

--- a/otodombot/db/models.py
+++ b/otodombot/db/models.py
@@ -1,5 +1,6 @@
-from sqlalchemy import Column, Integer, String, Boolean
-from sqlalchemy.orm import declarative_base
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, DateTime
+from sqlalchemy.orm import declarative_base, relationship
+from datetime import datetime
 
 Base = declarative_base()
 
@@ -9,7 +10,22 @@ class Listing(Base):
 
     id = Column(Integer, primary_key=True)
     url = Column(String, unique=True, nullable=False)
+    external_id = Column(Integer, unique=True)
     title = Column(String)
     location = Column(String)
     is_good = Column(Boolean, default=False)
     notes = Column(String)
+    price = Column(Integer)
+
+    price_history = relationship("PriceHistory", back_populates="listing", cascade="all, delete-orphan")
+
+
+class PriceHistory(Base):
+    __tablename__ = "price_history"
+
+    id = Column(Integer, primary_key=True)
+    listing_id = Column(Integer, ForeignKey("listings.id"), nullable=False)
+    price = Column(Integer, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    listing = relationship("Listing", back_populates="price_history")

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -3,7 +3,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 
 from ..scraper.crawler import OtodomCrawler
 from ..db.database import SessionLocal
-from ..db.models import Listing
+from ..db.models import Listing, PriceHistory
 from ..evaluation.location import evaluate_location
 from ..evaluation.chatgpt import rate_listing
 from ..notifications.telegram_bot import notify
@@ -14,16 +14,34 @@ def process_listings():
     links = crawler.fetch_listings()
     session = SessionLocal()
     for url in links:
-        if session.query(Listing).filter_by(url=url).first():
-            continue
         html = crawler.fetch_listing_details(url)
-        # simple placeholder evaluation
-        notes = rate_listing(html, api_key="YOUR_OPENAI_API_KEY")
-        location = evaluate_location("Warsaw", api_key="YOUR_GOOGLE_API_KEY")
-        listing = Listing(url=url, title="", location=str(location), notes=notes, is_good=True)
-        session.add(listing)
-        session.commit()
-        notify(token="YOUR_TELEGRAM_TOKEN", chat_id="CHAT_ID", messages=[f"Found listing: {url}"])
+        price = crawler.parse_price(html)
+        if price is None:
+            # skip listings without a price
+            continue
+
+        external_id = crawler.parse_listing_id(html)
+
+        listing = session.query(Listing).filter_by(url=url).first()
+        if not listing and external_id:
+            listing = session.query(Listing).filter_by(external_id=external_id).first()
+        if listing:
+            if external_id and listing.external_id != external_id:
+                listing.external_id = external_id
+            if listing.price != price:
+                listing.price = price
+                session.add(PriceHistory(listing=listing, price=price))
+            session.commit()
+        else:
+            # simple placeholder evaluation
+            notes = rate_listing(html, api_key="YOUR_OPENAI_API_KEY")
+            location = evaluate_location("Warsaw", api_key="YOUR_GOOGLE_API_KEY")
+            listing = Listing(url=url, external_id=external_id, title="", location=str(location), notes=notes, is_good=True, price=price)
+            session.add(listing)
+            session.commit()
+            session.add(PriceHistory(listing=listing, price=price))
+            session.commit()
+            notify(token="YOUR_TELEGRAM_TOKEN", chat_id="CHAT_ID", messages=[f"Found listing: {url}"])
     session.close()
 
 

--- a/otodombot/scraper/crawler.py
+++ b/otodombot/scraper/crawler.py
@@ -1,4 +1,5 @@
-from typing import List
+from typing import List, Optional
+import re
 from playwright.sync_api import sync_playwright
 
 
@@ -31,3 +32,34 @@ class OtodomCrawler:
             html = page.content()
             browser.close()
         return html
+
+    def parse_price(self, html: str) -> Optional[int]:
+        """Extract listing price from HTML."""
+        patterns = [
+            r"\"price\"\s*:\s*\{[^}]*\"value\"\s*:\s*(\d+)",
+            r"og:price:amount\" content=\"(\d+)",
+        ]
+        for pattern in patterns:
+            m = re.search(pattern, html)
+            if m:
+                try:
+                    return int(m.group(1))
+                except ValueError:
+                    continue
+        return None
+
+    def parse_listing_id(self, html: str) -> Optional[int]:
+        """Extract listing ID from HTML."""
+        patterns = [
+            r'"adId"\s*:\s*"?(\d+)',
+            r'"advertId"\s*:\s*(\d+)',
+            r'<meta property="og:url" content="[^"]*ID(\d+)',
+        ]
+        for pattern in patterns:
+            m = re.search(pattern, html)
+            if m:
+                try:
+                    return int(m.group(1))
+                except ValueError:
+                    continue
+        return None


### PR DESCRIPTION
## Summary
- store Otodom listing ID in `Listing.external_id`
- parse listing ID from HTML via new `parse_listing_id` helper
- update scheduler to record external ID when listings are processed
- mention ID storage in README

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q otodombot`


------
https://chatgpt.com/codex/tasks/task_e_684c5ac36170832eb1d401c60f7b7c01