### PR TITLE
Add listing description and location extraction

### DIFF
--- a/otodombot/db/models.py
+++ b/otodombot/db/models.py
@@ -12,6 +12,7 @@ class Listing(Base):
     url = Column(String, unique=True, nullable=False)
     external_id = Column(Integer, unique=True)
     title = Column(String)
+    description = Column(String)
     location = Column(String)
     is_good = Column(Boolean, default=False)
     notes = Column(String)

--- a/otodombot/evaluation/chatgpt.py
+++ b/otodombot/evaluation/chatgpt.py
@@ -9,3 +9,18 @@ def rate_listing(text: str, api_key: str) -> str:
         messages=[{"role": "user", "content": text}],
     )
     return response.choices[0].message["content"].strip()
+
+
+def extract_location(text: str, api_key: str) -> str:
+    """Use ChatGPT to guess the location from a description."""
+    openai.api_key = api_key
+    prompt = (
+        "Extract the most precise address or district mentioned in the listing "
+        "description. Respond with a short phrase or leave empty if unknown.\n\n"
+        f"{text}"
+    )
+    response = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message["content"].strip()


### PR DESCRIPTION
## Summary
- support pagination when fetching listing URLs
- parse description and address from listing pages
- add `description` column to `Listing` model
- deduce location via ChatGPT and Google Maps

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d65281964832eb80da936a198c1fe