### PR TITLE
Add headless mode config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ python -m otodombot.main
 
 ### Configuration
 
-Search conditions can be customized via `config.json` in the project root. Example:
+Search conditions and crawler settings can be customized via `config.json` in the project root. Example:
 
 ```json
 {
@@ -37,6 +37,9 @@ Search conditions can be customized via `config.json` in the project root. Examp
     "rooms": 2,
     "market": "secondary",
     "min_area": 40
-  }
+  },
+  "headless": true
 }
 ```
+
+The `headless` flag controls whether Playwright runs the browser without a visible window.

--- a/config.json
+++ b/config.json
@@ -4,5 +4,6 @@
     "rooms": 2,
     "market": "secondary",
     "min_area": 40
-  }
+  },
+  "headless": true
 }

--- a/otodombot/config.py
+++ b/otodombot/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Optional
@@ -18,17 +18,27 @@ class SearchConditions:
     min_area: Optional[int] = None
 
 
-def load_config(path: str | Path = "config.json") -> SearchConditions:
+@dataclass
+class Config:
+    search: SearchConditions = field(default_factory=SearchConditions)
+    headless: bool = True
+
+
+def load_config(path: str | Path = "config.json") -> Config:
     path = Path(path)
     if not path.exists():
-        return SearchConditions()
+        return Config()
     with path.open() as f:
         data = json.load(f)
     search = data.get("search", {})
     market = search.get("market", Market.SECONDARY.value)
-    return SearchConditions(
-        max_price=search.get("max_price"),
-        rooms=search.get("rooms"),
-        market=Market(market),
-        min_area=search.get("min_area"),
+    headless = data.get("headless", True)
+    return Config(
+        search=SearchConditions(
+            max_price=search.get("max_price"),
+            rooms=search.get("rooms"),
+            market=Market(market),
+            min_area=search.get("min_area"),
+        ),
+        headless=headless,
     )

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -13,8 +13,8 @@ from ..notifications.telegram_bot import notify
 
 def process_listings():
     logging.info("Starting listings processing")
-    search = load_config()
-    crawler = OtodomCrawler(search)
+    config = load_config()
+    crawler = OtodomCrawler(config.search, headless=config.headless)
     links = crawler.fetch_listings(max_pages=5)
     logging.info("Processing %d links", len(links))
     session = SessionLocal()

--- a/otodombot/scraper/crawler.py
+++ b/otodombot/scraper/crawler.py
@@ -11,8 +11,9 @@ class OtodomCrawler:
 
     BASE_URL = "https://www.otodom.pl/pl/oferty/sprzedaz/mieszkanie/warszawa"
 
-    def __init__(self, search: SearchConditions | None = None):
+    def __init__(self, search: SearchConditions | None = None, headless: bool = True):
         self.search = search or SearchConditions()
+        self.headless = headless
 
     def accept_cookies(self, page) -> None:
         """Attempt to accept cookie banners if present."""
@@ -52,7 +53,7 @@ class OtodomCrawler:
         logging.info("Fetching listings from %s", url)
         all_links: list[str] = []
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True)
+            browser = p.chromium.launch(headless=self.headless)
             context = browser.new_context(ignore_https_errors=True)
             page = context.new_page()
             current_url = url
@@ -79,7 +80,7 @@ class OtodomCrawler:
         """Placeholder for fetching a single listing page."""
         logging.debug("Fetching details for %s", url)
         with sync_playwright() as p:
-            browser = p.chromium.launch(headless=True)
+            browser = p.chromium.launch(headless=self.headless)
             context = browser.new_context(ignore_https_errors=True)
             page = context.new_page()
             page.goto(url)


### PR DESCRIPTION
## Summary
- support Playwright headless option via config
- expose the new option in config loader
- respect headless setting in crawler
- pass headless option from scheduled task
- document headless flag in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ddb05d1a4832ea21f37889d950f17