### PR TITLE
Fix price and listing id parsing

### DIFF
--- a/otodombot/scraper/crawler.py
+++ b/otodombot/scraper/crawler.py
@@ -126,12 +126,17 @@ class OtodomCrawler:
         patterns = [
             r"\"price\"\s*:\s*\{[^}]*\"value\"\s*:\s*(\d+)",
             r"og:price:amount\" content=\"(\d+)",
+            r"data-cy=\"adPageHeaderPrice\"[^>]*>([^<]+)<",
         ]
         for pattern in patterns:
             m = re.search(pattern, html)
             if m:
+                raw = m.group(1)
+                digits = re.sub(r"\D", "", raw)
+                if not digits:
+                    continue
                 try:
-                    price = int(m.group(1))
+                    price = int(digits)
                     logging.debug("Parsed price: %s", price)
                     return price
                 except ValueError:
@@ -141,6 +146,7 @@ class OtodomCrawler:
     def parse_listing_id(self, html: str) -> Optional[int]:
         """Extract listing ID from HTML."""
         patterns = [
+            r'<title>.*?(\d{5,}).*?</title>',
             r'"adId"\s*:\s*"?(\d+)',
             r'"advertId"\s*:\s*(\d+)',
             r'<meta property="og:url" content="[^"]*ID(\d+)',


### PR DESCRIPTION
## Summary
- parse price from `data-cy="adPageHeaderPrice"` element
- extract listing id from the title tag

## Testing
- `python -m otodombot.main` *(fails: requires interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_684ddf8de450832e80bc419db230758a