### PR TITLE
Load env vars from .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env and fill in your API keys
+OPENAI_API_KEY=your-openai-key
+GOOGLE_API_KEY=your-google-api-key
+TELEGRAM_TOKEN=your-telegram-token
+TELEGRAM_CHAT_ID=your-chat-id

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 venv/
 .env/
 .envrc
+!.env.example
 .env*
 
 # SQLite database files

--- a/README.md
+++ b/README.md
@@ -43,3 +43,16 @@ Search conditions and crawler settings can be customized via `config.json` in th
 ```
 
 The `headless` flag controls whether Playwright runs the browser without a visible window.
+
+### Environment variables
+
+API keys and tokens are loaded from environment variables. Create a `.env` file in the project root (see `.env.example`) with the following keys:
+
+```env
+OPENAI_API_KEY=your-openai-key
+GOOGLE_API_KEY=your-google-api-key
+TELEGRAM_TOKEN=your-telegram-token
+TELEGRAM_CHAT_ID=your-chat-id
+```
+
+The application automatically loads this file on startup if present.

--- a/otodombot/main.py
+++ b/otodombot/main.py
@@ -1,10 +1,12 @@
 import logging
+from dotenv import load_dotenv
 
 from .db.database import init_db
 from .scheduler.tasks import start_scheduler
 
 
 def main():
+    load_dotenv()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     init_db()
     start_scheduler()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ apscheduler
 python-telegram-bot
 googlemaps
 sqlalchemy
+python-dotenv


### PR DESCRIPTION
## Summary
- load environment variables via `python-dotenv`
- allow `.env.example` template in repo
- document required environment variables in README
- use env vars in scheduler tasks
- autoload `.env` in main entrypoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install python-dotenv`
- `python -m otodombot.main` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684de9466588832ea2cc56512230ad63