### PR TITLE
Remove Google Maps API usage

### DIFF
--- a/otodombot/evaluation/chatgpt.py
+++ b/otodombot/evaluation/chatgpt.py
@@ -24,3 +24,22 @@ def extract_location(text: str, api_key: str) -> str:
         messages=[{"role": "user", "content": prompt}],
     )
     return response.choices[0].message.content.strip()
+
+
+def extract_address(
+    description: str, page_address: str, html: str, api_key: str
+) -> str:
+    """Use ChatGPT to extract a full address from the listing page."""
+    client = OpenAI(api_key=api_key)
+    trimmed_html = html[:12000]
+    prompt = (
+        "Given the raw address snippet and the listing description, "
+        "find the most precise address of the property. "
+        "Respond with only the address or leave empty if unsure.\n\n"
+        f"Address snippet: {page_address}\n\nDescription:\n{description}\n\nHTML:\n{trimmed_html}"
+    )
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content.strip()

--- a/otodombot/evaluation/location.py
+++ b/otodombot/evaluation/location.py
@@ -1,11 +1,3 @@
-import googlemaps
-
-
 def evaluate_location(address: str, api_key: str) -> dict:
-    """Evaluate location using Google Maps API."""
-    gmaps = googlemaps.Client(key=api_key)
-    geocode = gmaps.geocode(address)
-    if not geocode:
-        return {}
-    location = geocode[0]["geometry"]["location"]
-    return location
+    """Placeholder for location evaluation without Google API."""
+    return {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ openai
 dotenv
 apscheduler
 python-telegram-bot
-googlemaps
 sqlalchemy
 python-dotenv


### PR DESCRIPTION
## Summary
- avoid googlemaps dependency and stub evaluation
- add ChatGPT helper to guess address from page HTML
- use the helper in listing processing
- scroll listing pages to load dynamic content
- drop googlemaps from requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684dec7cb330832eadc97ddaef3851f7