### PR TITLE
Reduce ChatGPT input size

### DIFF
--- a/otodombot/evaluation/chatgpt.py
+++ b/otodombot/evaluation/chatgpt.py
@@ -2,7 +2,7 @@ from openai import OpenAI
 
 
 def rate_listing(text: str, api_key: str) -> str:
-    """Use ChatGPT to rate a listing."""
+    """Use ChatGPT to rate a listing based on a short summary."""
     client = OpenAI(api_key=api_key)
     response = client.chat.completions.create(
         model="gpt-4o",

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -94,8 +94,18 @@ def process_listings():
             session.commit()
             logging.info("Updated listing %s", url)
         else:
-            # simple placeholder evaluation
-            notes = rate_listing(html, api_key=openai_key) if openai_key else ""
+            # Build a short summary for ChatGPT instead of sending full HTML
+            summary_lines = [
+                f"Title: {title}",
+                f"Price: {price}",
+            ]
+            if address:
+                summary_lines.append(f"Address: {address}")
+            if description:
+                summary_lines.append("Description:\n" + description[:4000])
+            summary = "\n".join(summary_lines)
+
+            notes = rate_listing(summary, api_key=openai_key) if openai_key else ""
             listing = Listing(
                 url=url,
                 external_id=external_id,


### PR DESCRIPTION
## Summary
- avoid sending raw HTML to ChatGPT by building a short summary of listing data
- document that `rate_listing` expects a short summary

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684deeb56d10832e8b48591ea8a1c5c0