### PR TITLE
Remove price field from listings and filter photos

### DIFF
--- a/otodombot/db/models.py
+++ b/otodombot/db/models.py
@@ -16,7 +16,6 @@ class Listing(Base):
     location = Column(String)
     is_good = Column(Boolean, default=False)
     notes = Column(String)
-    price = Column(Integer)
 
     price_history = relationship("PriceHistory", back_populates="listing", cascade="all, delete-orphan")
     photos = relationship("Photo", back_populates="listing", cascade="all, delete-orphan")

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -77,8 +77,13 @@ def process_listings():
         if listing:
             if external_id and listing.external_id != external_id:
                 listing.external_id = external_id
-            if listing.price != price:
-                listing.price = price
+            last_price_entry = (
+                session.query(PriceHistory)
+                .filter_by(listing_id=listing.id)
+                .order_by(PriceHistory.timestamp.desc())
+                .first()
+            )
+            if not last_price_entry or last_price_entry.price != price:
                 session.add(PriceHistory(listing=listing, price=price))
             session.commit()
             # store new photos if not present
@@ -114,7 +119,6 @@ def process_listings():
                 location=address,
                 notes=notes,
                 is_good=True,
-                price=price,
             )
             session.add(listing)
             session.commit()

--- a/otodombot/scraper/crawler.py
+++ b/otodombot/scraper/crawler.py
@@ -236,6 +236,8 @@ class OtodomCrawler:
         seen = set()
         unique_urls = []
         for url in urls:
+            if "olxcdn" not in url:
+                continue
             if url not in seen:
                 unique_urls.append(url)
                 seen.add(url)


### PR DESCRIPTION
## Summary
- remove price column from `Listing`
- record prices only in `PriceHistory`
- filter scraper photo URLs to only grab otodom images
- update scheduler logic for price history without storing price on listing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684df1321270832e98187a00588b07c0