### PR TITLE
Improve extract_address logic

### DIFF
--- a/otodombot/evaluation/chatgpt.py
+++ b/otodombot/evaluation/chatgpt.py
@@ -1,4 +1,5 @@
 from openai import OpenAI
+from bs4 import BeautifulSoup
 
 
 def rate_listing(text: str, api_key: str) -> str:
@@ -31,12 +32,39 @@ def extract_address(
 ) -> str:
     """Use ChatGPT to extract a full address from the listing page."""
     client = OpenAI(api_key=api_key)
-    trimmed_html = html[:12000]
+
+    # Parse the HTML and try to get only the main listing content instead of the
+    # entire page. This helps the model focus on the actual ad text rather than
+    # boilerplate or agency info.
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "noscript"]):
+        tag.decompose()
+
+    block = ""
+    candidates = [
+        {"data-cy": "adPageMainContent"},
+        {"data-cy": "adPageAdDescription"},
+        {"id": "adPageMainContent"},
+        {"class": "offer-details"},
+    ]
+    for attrs in candidates:
+        el = soup.find(attrs=attrs)
+        if el:
+            block = el.get_text(" ", strip=True)
+            break
+    if not block:
+        el = soup.find("article") or soup.find("main") or soup.body
+        if el:
+            block = el.get_text(" ", strip=True)
+
+    trimmed_block = block[:10000]
+
     prompt = (
-        "Given the raw address snippet and the listing description, "
-        "find the most precise address of the property. "
-        "Respond with only the address or leave empty if unsure.\n\n"
-        f"Address snippet: {page_address}\n\nDescription:\n{description}\n\nHTML:\n{trimmed_html}"
+        "Given the raw address snippet, the listing description and the main "
+        "content block from the page, locate the address of the flat itself "
+        "(not the agency). Respond only with the address or leave empty if "
+        "unsure.\n\n"
+        f"Address snippet: {page_address}\n\nDescription:\n{description}\n\nListing content:\n{trimmed_block}"
     )
     response = client.chat.completions.create(
         model="gpt-4o",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ apscheduler
 python-telegram-bot
 sqlalchemy
 python-dotenv
+beautifulsoup4


### PR DESCRIPTION
## Summary
- parse listing HTML with BeautifulSoup to extract main listing block
- craft ChatGPT prompt using this block instead of the whole HTML
- add BeautifulSoup to requirements

## Testing
- `python -m py_compile otodombot/evaluation/chatgpt.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68543d3d59b4832e9ad85741a1c8210e