### PR TITLE
Simplify model to store price directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Skeleton project for parsing [otodom.pl](https://www.otodom.pl) and notifying ab
 - `evaluation/` – modules for location and ChatGPT evaluation.
 - `notifications/` – Telegram bot notifier.
 - `scheduler/` – APScheduler based periodic tasks.
-- Price history is stored for each listing and updated when prices change.
+- Each listing stores its current price directly.
 - Listing ID is parsed from the listing page and stored for reference.
 
 ## Usage

--- a/otodombot/db/models.py
+++ b/otodombot/db/models.py
@@ -14,23 +14,12 @@ class Listing(Base):
     title = Column(String)
     description = Column(String)
     location = Column(String)
+    price = Column(Integer)
     is_good = Column(Boolean, default=False)
     notes = Column(String)
     last_parsed = Column(DateTime, default=datetime.utcnow)
 
-    price_history = relationship("PriceHistory", back_populates="listing", cascade="all, delete-orphan")
     photos = relationship("Photo", back_populates="listing", cascade="all, delete-orphan")
-
-
-class PriceHistory(Base):
-    __tablename__ = "price_history"
-
-    id = Column(Integer, primary_key=True)
-    listing_id = Column(Integer, ForeignKey("listings.id"), nullable=False)
-    price = Column(Integer, nullable=False)
-    timestamp = Column(DateTime, default=datetime.utcnow)
-
-    listing = relationship("Listing", back_populates="price_history")
 
 
 class Photo(Base):


### PR DESCRIPTION
## Summary
- drop `PriceHistory` model
- move `price` onto `Listing`
- update scheduler to persist listing price directly
- document database simplification in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bdd54640832e8fbc732521168b18