### PR TITLE
Allow multiple room counts in search config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ python -m otodombot.main
 
 ### Configuration
 
-Search conditions and crawler settings can be customized via `config.json` in the project root. Example:
+Search conditions and crawler settings can be customized via `config.json` in the project root. Rooms can be specified as a single value or an array of options. Example:
 
 ```json
 {
   "search": {
     "max_price": 1000000,
-    "rooms": 2,
+    "rooms": [2, 3],
     "market": "secondary",
     "min_area": 40
   },

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "search": {
     "max_price": 900000,
-    "rooms": 3,
+    "rooms": [3, 4],
     "market": "secondary",
     "min_area": 60
   },

--- a/otodombot/config.py
+++ b/otodombot/config.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List
 import json
 
 
@@ -13,7 +13,7 @@ class Market(str, Enum):
 @dataclass
 class SearchConditions:
     max_price: Optional[int] = None
-    rooms: Optional[int] = None
+    rooms: Optional[List[int]] = None
     market: Market = Market.SECONDARY
     min_area: Optional[int] = None
 
@@ -33,10 +33,25 @@ def load_config(path: str | Path = "config.json") -> Config:
     search = data.get("search", {})
     market = search.get("market", Market.SECONDARY.value)
     headless = data.get("headless", True)
+
+    rooms_value = search.get("rooms")
+    rooms: Optional[List[int]]
+    if isinstance(rooms_value, list):
+        rooms = [int(r) for r in rooms_value if isinstance(r, int) or (isinstance(r, str) and r.isdigit())]
+        if not rooms:
+            rooms = None
+    elif rooms_value is not None:
+        try:
+            rooms = [int(rooms_value)]
+        except (TypeError, ValueError):
+            rooms = None
+    else:
+        rooms = None
+
     return Config(
         search=SearchConditions(
             max_price=search.get("max_price"),
-            rooms=search.get("rooms"),
+            rooms=rooms,
             market=Market(market),
             min_area=search.get("min_area"),
         ),

--- a/otodombot/scraper/crawler.py
+++ b/otodombot/scraper/crawler.py
@@ -49,7 +49,8 @@ class OtodomCrawler:
         if self.search.max_price:
             params.append(f"priceMax={self.search.max_price}")
         if self.search.rooms:
-            params.append(f"roomsNumber={self.search.rooms}")
+            rooms_param = ",".join(str(r) for r in self.search.rooms)
+            params.append(f"roomsNumber={rooms_param}")
         if self.search.market:
             params.append(f"market={self.search.market.value}")
         if self.search.min_area:


### PR DESCRIPTION
## Summary
- support arrays for `rooms` in search config
- update config loading logic for lists
- document array usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855be9a44bc832eb5ee1f20bea3f0a9