### PR TITLE
Add Telegram chat id helper bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Run the bot:
 python -m otodombot.main
 ```
 
+Get your Telegram chat ID:
+
+```bash
+python -m otodombot.chat_id_bot
+```
+Send any message to the bot and it will respond with your chat ID.
+
 ### Configuration
 
 Search conditions and crawler settings can be customized via `config.json` in the project root. Room counts may be specified as a single number or a list of numbers; these are automatically converted to the values expected by Otodom. Example:

--- a/otodombot/chat_id_bot.py
+++ b/otodombot/chat_id_bot.py
@@ -1,0 +1,34 @@
+import logging
+import os
+
+from dotenv import load_dotenv
+from telegram import Update
+from telegram.ext import (
+    ApplicationBuilder,
+    CommandHandler,
+    MessageHandler,
+    ContextTypes,
+    filters,
+)
+
+
+async def send_chat_id(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Reply with the chat ID of the current conversation."""
+    chat_id = update.effective_chat.id
+    await context.bot.send_message(chat_id=chat_id, text=f"Chat ID: {chat_id}")
+
+
+def main() -> None:
+    load_dotenv()
+    token = os.getenv("TELEGRAM_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_TOKEN not set")
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    application = ApplicationBuilder().token(token).build()
+    application.add_handler(CommandHandler("start", send_chat_id))
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, send_chat_id))
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `chat_id_bot` entrypoint for Telegram chat id
- document how to use the helper bot in README

## Testing
- `python -m py_compile otodombot/chat_id_bot.py`
- `python -m otodombot.chat_id_bot --help` *(fails: TELEGRAM_TOKEN not set)*
- `python -m otodombot.main --help` *(fails: requires Playwright browsers)*
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6855cfefa81c832ea1a5b854f2a0157b