### PR TITLE
Stop saving photos locally

### DIFF
--- a/otodombot/notifications/telegram_bot.py
+++ b/otodombot/notifications/telegram_bot.py
@@ -1,5 +1,6 @@
 from typing import Iterable
 import asyncio
+from pathlib import Path
 from telegram import Bot, InputMediaPhoto
 
 
@@ -21,15 +22,19 @@ def notify_listing(
     async def _send():
         bot = Bot(token=token)
         if photos:
-            files = []
             media = []
-            for idx, path in enumerate(list(photos)[:10]):
-                f = open(path, "rb")
-                files.append(f)
-                if idx == 0:
-                    media.append(InputMediaPhoto(f, caption=text))
+            files = []
+            for idx, item in enumerate(list(photos)[:10]):
+                if Path(item).exists():
+                    f = open(item, "rb")
+                    files.append(f)
+                    photo_input = f
                 else:
-                    media.append(InputMediaPhoto(f))
+                    photo_input = item
+                if idx == 0:
+                    media.append(InputMediaPhoto(photo_input, caption=text))
+                else:
+                    media.append(InputMediaPhoto(photo_input))
             await bot.send_media_group(chat_id=chat_id, media=media)
             for f in files:
                 f.close()


### PR DESCRIPTION
## Summary
- simplify Telegram photo sending
- do not download or store listing photos

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d3f635a8832eb373d4b495ad49cd