### PR TITLE
Enable sorting modes in crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Search conditions and crawler settings can be customized via `config.json` in th
     "max_price": 1000000,
     "rooms": [2, 3],
     "market": "secondary",
-    "min_area": 40
+    "min_area": 40,
+    "sorts": ["DEFAULT", "LATEST"]
   },
   "headless": true
   ,"commute": {
@@ -59,6 +60,7 @@ Search conditions and crawler settings can be customized via `config.json` in th
 ```
 
 The `headless` flag controls whether Playwright runs the browser without a visible window.
+The `sorts` option defines which sorting modes to fetch (e.g. `"DEFAULT"` or `"LATEST"`). Listings are collected for each specified mode in one session.
 `commute` config defines destinations for public transit time estimation. The bot will
 calculate travel times from each listing to these addresses for the specified day and time.
 If the times to all points do not exceed the optional `thresholds` values (in minutes),

--- a/config.json
+++ b/config.json
@@ -6,7 +6,8 @@
       4
     ],
     "market": "secondary",
-    "min_area": 60
+    "min_area": 60,
+    "sorts": ["DEFAULT", "LATEST"]
   },
   "headless": false,
   "commute": {

--- a/otodombot/config.py
+++ b/otodombot/config.py
@@ -16,6 +16,7 @@ class SearchConditions:
     rooms: Optional[List[int]] = None
     market: Market = Market.SECONDARY
     min_area: Optional[int] = None
+    sorts: List[str] = field(default_factory=lambda: ["DEFAULT"])
 
 
 @dataclass
@@ -65,12 +66,23 @@ def load_config(path: str | Path = "config.json") -> Config:
         thresholds={k: int(v) for k, v in commute_data.get("thresholds", {}).items() if isinstance(v, (int, str)) and str(v).isdigit()},
     )
 
+    sorts_value = search.get("sorts", ["DEFAULT"])
+    if isinstance(sorts_value, list):
+        sorts = [str(s).upper() for s in sorts_value if isinstance(s, (str, int))]
+        if not sorts:
+            sorts = ["DEFAULT"]
+    elif sorts_value is not None:
+        sorts = [str(sorts_value).upper()]
+    else:
+        sorts = ["DEFAULT"]
+
     return Config(
         search=SearchConditions(
             max_price=search.get("max_price"),
             rooms=rooms,
             market=Market(market),
             min_area=search.get("min_area"),
+            sorts=sorts,
         ),
         headless=headless,
         commute=commute,

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -46,7 +46,11 @@ def process_listings():
         for l in session.query(Listing)
         .filter((Listing.last_parsed == None) | (Listing.last_parsed < stale_cutoff))
     ]
-    links = stale_urls + crawler.fetch_listings(max_pages=5)
+    fetched: list[str] = []
+    for sort in config.search.sorts:
+        logging.info("Fetching listings using sort %s", sort)
+        fetched.extend(crawler.fetch_listings(max_pages=5, sort_by=sort))
+    links = stale_urls + fetched
     links = list(dict.fromkeys(links))
     logging.info("Processing %d links", len(links))
     for url in links:

--- a/otodombot/scraper/crawler.py
+++ b/otodombot/scraper/crawler.py
@@ -45,7 +45,7 @@ class OtodomCrawler:
             except Exception:
                 continue
 
-    def build_url(self) -> str:
+    def build_url(self, sort_by: str = "DEFAULT") -> str:
         params: list[str] = []
         if self.search.max_price:
             params.append(f"priceMax={self.search.max_price}")
@@ -69,13 +69,17 @@ class OtodomCrawler:
             params.append(f"market={self.search.market.value}")
         if self.search.min_area:
             params.append(f"areaMin={self.search.min_area}")
-        params.append("by=created_at:desc")
+        sort = sort_by.upper() if sort_by else "DEFAULT"
+        if sort == "LATEST":
+            params.append("by=LATEST&direction=DESC")
+        else:
+            params.append("by=DEFAULT&direction=DESC")
         query = "&".join(params)
         url = self.BASE_URL + ("?" + query if query else "")
         logging.debug("Built search URL: %s", url)
         return url
 
-    def fetch_listings(self, max_pages: int = 3) -> List[str]:
+    def fetch_listings(self, max_pages: int = 3, sort_by: str = "DEFAULT") -> List[str]:
         """Fetch listing URLs from otodom following pagination.
 
         Parameters
@@ -84,8 +88,11 @@ class OtodomCrawler:
             Number of result pages to crawl in a single session. Defaults
             to ``3`` so that multiple pages are processed without the
             caller needing to pass an argument.
+        sort_by : str, optional
+            Sorting to use for fetching listings. Supported values are
+            ``"DEFAULT"`` and ``"LATEST"``. Defaults to ``"DEFAULT"``.
         """
-        url = self.build_url()
+        url = self.build_url(sort_by=sort_by)
         logging.info("Fetching listings from %s", url)
         all_links: list[str] = []
         with sync_playwright() as p:


### PR DESCRIPTION
## Summary
- add `sorts` to search config and parse it from `config.json`
- add `sorts` explanation in README
- support `sort_by` parameter in `OtodomCrawler`
- fetch listings for each sort during scheduled processing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855db05ac78832ebe761519a1903d3e