### PR TITLE
Improve Telegram listing message formatting

### DIFF
--- a/otodombot/notifications/telegram_bot.py
+++ b/otodombot/notifications/telegram_bot.py
@@ -8,7 +8,7 @@ def notify(token: str, chat_id: str, messages: Iterable[str]):
     async def _send():
         bot = Bot(token=token)
         for msg in messages:
-            await bot.send_message(chat_id=chat_id, text=msg)
+            await bot.send_message(chat_id=chat_id, text=msg, parse_mode="HTML")
 
     asyncio.run(_send())
 
@@ -32,13 +32,13 @@ def notify_listing(
                 else:
                     photo_input = item
                 if idx == 0:
-                    media.append(InputMediaPhoto(photo_input, caption=text))
+                    media.append(InputMediaPhoto(photo_input, caption=text, parse_mode="HTML"))
                 else:
                     media.append(InputMediaPhoto(photo_input))
             await bot.send_media_group(chat_id=chat_id, media=media)
             for f in files:
                 f.close()
         else:
-            await bot.send_message(chat_id=chat_id, text=text)
+            await bot.send_message(chat_id=chat_id, text=text, parse_mode="HTML")
 
     asyncio.run(_send())

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -166,15 +166,16 @@ def process_listings():
                         listing.notes = rate_listing(summary, api_key=openai_key)
                         session.commit()
 
-                    text_lines = [f"{listing.title}", f"Price: {listing.price}"]
+                    text_lines = [f"<b>{listing.title}</b>"]
+                    text_lines.append(f"<b>\ud83d\udcb0 Price:</b> {listing.price}")
                     if listing.location:
-                        text_lines.append(f"Address: {listing.location}")
+                        text_lines.append(f"<b>\ud83d\udccd Address:</b> {listing.location}")
                     if listing.notes:
-                        text_lines.append(f"AI summary:\n{listing.notes}")
+                        text_lines.append(f"<b>\ud83e\udd16 AI summary:</b>\n{listing.notes}")
                     for poi in config.commute.pois:
                         minutes = info.get(poi)
                         if minutes is not None:
-                            text_lines.append(f"{poi}: {minutes} min")
+                            text_lines.append(f"<b>\ud83d\ude8d {poi}:</b> {minutes} min")
                     text_lines.append(listing.url)
                     notify_listing(
                         token=telegram_token,


### PR DESCRIPTION
## Summary
- use `parse_mode="HTML"` for Telegram messages
- add bold labels and emojis for listing notifications

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q otodombot`


------
https://chatgpt.com/codex/tasks/task_e_6855dbf94d1c832e80b25514a74a6ab6