### PR TITLE
Add backend API and map frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,15 @@ TELEGRAM_CHAT_ID=12345,67890
 ```
 
 The application automatically loads this file on startup if present.
+
+### Backend and map frontend
+
+A small FastAPI server exposes listing locations so they can be visualized on a map.
+Start it with:
+
+```bash
+python -m otodombot.backend
+```
+
+Then open `frontend/index.html` in a browser. It fetches data from the API and
+shows the listings on an OpenStreetMap-based map using Leaflet.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Otodom Listings Map</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <style>
+        #map { height: 100vh; }
+    </style>
+</head>
+<body>
+<div id="map"></div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script>
+const map = L.map('map').setView([52.2297, 21.0122], 11);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '© OpenStreetMap contributors'
+}).addTo(map);
+
+fetch('http://localhost:8000/listings')
+  .then(r => r.json())
+  .then(listings => {
+    listings.forEach(l => {
+      const marker = L.marker([l.lat, l.lng]).addTo(map);
+      const html = `<b>${l.title}</b><br/><b>Price:</b> ${l.price}<br/><a href="${l.url}" target="_blank">Open</a>`;
+      marker.bindPopup(html);
+    });
+  })
+  .catch(err => console.error(err));
+</script>
+</body>
+</html>

--- a/otodombot/backend.py
+++ b/otodombot/backend.py
@@ -1,0 +1,63 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+import uvicorn
+
+from .db.database import init_db, SessionLocal
+from .db.models import Listing
+
+app = FastAPI(title="Otodom Listings API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.on_event("startup")
+def on_startup():
+    init_db()
+
+@app.get("/listings")
+def get_listings():
+    session = SessionLocal()
+    listings = [
+        {
+            "id": l.id,
+            "title": l.title,
+            "lat": l.lat,
+            "lng": l.lng,
+            "price": l.price,
+            "url": l.url,
+        }
+        for l in session.query(Listing).all()
+        if l.lat is not None and l.lng is not None
+    ]
+    session.close()
+    return listings
+
+@app.get("/listings/{listing_id}")
+def get_listing(listing_id: int):
+    session = SessionLocal()
+    listing = session.query(Listing).get(listing_id)
+    session.close()
+    if not listing:
+        return {"detail": "Listing not found"}
+    return {
+        "id": listing.id,
+        "title": listing.title,
+        "description": listing.description,
+        "location": listing.location,
+        "price": listing.price,
+        "lat": listing.lat,
+        "lng": listing.lng,
+        "notes": listing.notes,
+        "url": listing.url,
+    }
+
+def main():
+    uvicorn.run("otodombot.backend:app", host="0.0.0.0", port=8000, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ sqlalchemy
 python-dotenv
 beautifulsoup4
 googlemaps
+
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- provide FastAPI backend entrypoint to query listings
- create simple Leaflet-based webpage for displaying listings on a map
- add FastAPI and Uvicorn to requirements
- document how to run backend and map frontend in README

## Testing
- `pip install -r requirements.txt`
- `python -m otodombot.backend` (started and shut down successfully)

------
https://chatgpt.com/codex/tasks/task_e_6855e0473908832ebce0e2e5970e0658