### PR TITLE
Add commute times to map

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,5 @@ python -m otodombot.backend
 ```
 
 Then open `frontend/index.html` in a browser. It fetches data from the API and
-shows the listings on an OpenStreetMap-based map using Leaflet.
+shows the listings on an OpenStreetMap-based map using Leaflet. Popups include
+calculated travel times to your configured points of interest.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,8 +22,19 @@ fetch('http://localhost:8000/listings')
   .then(listings => {
     listings.forEach(l => {
       const marker = L.marker([l.lat, l.lng]).addTo(map);
-      const html = `<b>${l.title}</b><br/><b>Price:</b> ${l.price}<br/><a href="${l.url}" target="_blank">Open</a>`;
-      marker.bindPopup(html);
+      const lines = [
+        `<b>${l.title}</b>`,
+        `<b>Price:</b> ${l.price}`
+      ];
+      if (l.commutes) {
+        Object.entries(l.commutes).forEach(([dest, min]) => {
+          if (min !== null) {
+            lines.push(`<b>\ud83d\ude8d ${dest}:</b> ${min} min`);
+          }
+        });
+      }
+      lines.push(`<a href="${l.url}" target="_blank">Open</a>`);
+      marker.bindPopup(lines.join('<br/>'));
     });
   })
   .catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- expose commute time data via the backend API
- show commute times for each listing on the Leaflet map
- update README about map popups

## Testing
- `python -m py_compile otodombot/backend.py`

------
https://chatgpt.com/codex/tasks/task_e_68566e50b304832eb38010e29cee4551