### PR TITLE
Add card layout with hover pin highlight

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,10 @@
     <meta charset="utf-8" />
     <title>Otodom Listings Map</title>
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
+    />
     <style>
         html, body {
             height: 100%;
@@ -26,11 +30,10 @@
             box-sizing: border-box;
         }
         #listingList {
-            list-style: none;
-            padding-left: 0;
-        }
-        #listingList li {
-            margin-bottom: 8px;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            padding: 0;
         }
     </style>
 </head>
@@ -39,8 +42,8 @@
   <div id="map"></div>
   <div id="sidebar">
     <label for="sortSelect">Sort by commute to:</label>
-    <select id="sortSelect"></select>
-    <ul id="listingList"></ul>
+    <select id="sortSelect" class="form-select mb-2"></select>
+    <div id="listingList"></div>
   </div>
 </div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
@@ -51,6 +54,18 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 }).addTo(map);
 
 let listingsData = [];
+const markers = {};
+const defaultIcon = new L.Icon.Default();
+const highlightIcon = new L.Icon({
+  iconUrl:
+    'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
+  shadowUrl:
+    'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+  popupAnchor: [1, -34],
+  shadowSize: [41, 41],
+});
 
 function populateSortOptions(listings) {
   const select = document.getElementById('sortSelect');
@@ -81,17 +96,36 @@ function renderList(dest) {
   }
   list.innerHTML = '';
   arr.forEach(l => {
-    const li = document.createElement('li');
-    const a = document.createElement('a');
-    a.href = l.url;
-    a.target = '_blank';
-    let text = `${l.title} - ${l.price}`;
+    const card = document.createElement('div');
+    card.className = 'card listing-card';
+    card.dataset.id = l.id;
+
+    const img = document.createElement('img');
+    img.className = 'card-img-top';
+    img.src = l.photo_url || 'https://via.placeholder.com/150';
+    card.appendChild(img);
+
+    const body = document.createElement('div');
+    body.className = 'card-body p-2';
+    const title = document.createElement('h5');
+    title.className = 'card-title h6';
+    title.textContent = l.title;
+    body.appendChild(title);
+    const price = document.createElement('p');
+    price.className = 'card-text small mb-0';
+    let text = `${l.price}`;
     if (dest && l.commutes && l.commutes[dest] !== undefined && l.commutes[dest] !== null) {
       text += ` (${l.commutes[dest]} min)`;
     }
-    a.textContent = text;
-    li.appendChild(a);
-    list.appendChild(li);
+    price.textContent = text;
+    body.appendChild(price);
+    card.appendChild(body);
+
+    card.addEventListener('click', () => window.open(l.url, '_blank'));
+    card.addEventListener('mouseenter', () => highlightMarker(l.id));
+    card.addEventListener('mouseleave', () => unhighlightMarker(l.id));
+
+    list.appendChild(card);
   });
 }
 
@@ -102,7 +136,8 @@ fetch('http://localhost:8000/listings')
     populateSortOptions(listingsData);
     renderList();
     listings.forEach(l => {
-      const marker = L.marker([l.lat, l.lng]).addTo(map);
+      const marker = L.marker([l.lat, l.lng], { icon: defaultIcon }).addTo(map);
+      markers[l.id] = marker;
       const lines = [
         `<b>${l.title}</b>`,
         `<b>Price:</b> ${l.price}`
@@ -124,6 +159,22 @@ document.getElementById('sortSelect').addEventListener('change', (e) => {
   const dest = e.target.value || null;
   renderList(dest);
 });
+
+function highlightMarker(id) {
+  const m = markers[id];
+  if (m) {
+    m.setIcon(highlightIcon);
+    m.setZIndexOffset(1000);
+  }
+}
+
+function unhighlightMarker(id) {
+  const m = markers[id];
+  if (m) {
+    m.setIcon(defaultIcon);
+    m.setZIndexOffset(0);
+  }
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- improve frontend by using Bootstrap card layout
- show placeholders for listing photos and highlight pins on hover

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685675b63024832ebd5619380870f2c3