### PR TITLE
Remove image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The `sorts` option defines which sorting modes to fetch (e.g. `"DEFAULT"` or `"L
 `commute` config defines destinations for public transit time estimation. The bot will
 calculate travel times from each listing to these addresses for the specified day and time.
 If the times to all points do not exceed the optional `thresholds` values (in minutes),
-the bot sends the listing details and photos to Telegram.
+the bot sends the listing details to Telegram.
 
 ### Environment variables
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -100,11 +100,6 @@ function renderList(dest) {
     card.className = 'card listing-card';
     card.dataset.id = l.id;
 
-    const img = document.createElement('img');
-    img.className = 'card-img-top';
-    img.src = l.photo_url || 'https://via.placeholder.com/150';
-    card.appendChild(img);
-
     const body = document.createElement('div');
     body.className = 'card-body p-2';
     const title = document.createElement('h5');

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -44,7 +44,6 @@ def process_single_listing(url, crawler, session, config, openai_key, google_key
         title = crawler.parse_title(html)
         description = crawler.parse_description(html)
         address = ''
-        photos = crawler.parse_photos(html)
         if openai_key:
             address = extract_address(
                 description=description,
@@ -158,7 +157,6 @@ def process_single_listing(url, crawler, session, config, openai_key, google_key
                         token=telegram_token,
                         chat_id=telegram_chat_ids,
                         text="\n".join(text_lines),
-                        photos=photos[:3],
                     )
     except Exception as e:
         logging.error(f"Error processing listing {url}: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- drop photo parsing and notifications
- stop displaying images in frontend cards
- clarify README that only text gets sent

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_685676f6765c832eb8788056238d84e0