### PR TITLE
Update config to handle base URL, remove market option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Search conditions and crawler settings can be customized via `config.json` in th
   "search": {
     "max_price": 1000000,
     "rooms": [2, 3],
-    "market": "secondary",
     "min_area": 40,
     "sorts": ["DEFAULT", "LATEST"]
   },
+  "base_url": "https://www.otodom.pl/pl/oferty/sprzedaz/mieszkanie,rynek-wtorny/warszawa",
   "headless": true,
   "reparse_after_days": 7,
   "commute": {

--- a/config.json
+++ b/config.json
@@ -5,13 +5,13 @@
       3,
       4
     ],
-    "market": "secondary",
     "min_area": 65,
     "sorts": [
       "DEFAULT",
       "LATEST"
     ]
   },
+  "base_url": "https://www.otodom.pl/pl/oferty/sprzedaz/mieszkanie,rynek-wtorny/warszawa",
   "headless": true,
   "reparse_after_days": 7,
   "commute": {

--- a/otodombot/config.py
+++ b/otodombot/config.py
@@ -1,20 +1,15 @@
 from dataclasses import dataclass, field
-from enum import Enum
 from pathlib import Path
 from typing import Optional, List
 import json
 
 
-class Market(str, Enum):
-    PRIMARY = "primary"
-    SECONDARY = "secondary"
-
+DEFAULT_BASE_URL = "https://www.otodom.pl/pl/oferty/sprzedaz/mieszkanie,rynek-wtorny/warszawa"
 
 @dataclass
 class SearchConditions:
     max_price: Optional[int] = None
     rooms: Optional[List[int]] = None
-    market: Market = Market.SECONDARY
     min_area: Optional[int] = None
     sorts: List[str] = field(default_factory=lambda: ["DEFAULT"])
 
@@ -31,6 +26,7 @@ class CommuteSettings:
 class Config:
     search: SearchConditions = field(default_factory=SearchConditions)
     headless: bool = True
+    base_url: str = DEFAULT_BASE_URL
     commute: CommuteSettings = field(default_factory=CommuteSettings)
     reparse_after_days: int = 7
 
@@ -42,8 +38,8 @@ def load_config(path: str | Path = "config.json") -> Config:
     with path.open() as f:
         data = json.load(f)
     search = data.get("search", {})
-    market = search.get("market", Market.SECONDARY.value)
     headless = data.get("headless", True)
+    base_url = data.get("base_url", DEFAULT_BASE_URL)
     reparse_after_days = int(data.get("reparse_after_days", 7))
     commute_data = data.get("commute", {})
 
@@ -82,11 +78,11 @@ def load_config(path: str | Path = "config.json") -> Config:
         search=SearchConditions(
             max_price=search.get("max_price"),
             rooms=rooms,
-            market=Market(market),
             min_area=search.get("min_area"),
             sorts=sorts,
         ),
         headless=headless,
+        base_url=base_url,
         commute=commute,
         reparse_after_days=reparse_after_days,
     )

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -167,7 +167,9 @@ def process_single_listing(url, crawler, session, config, openai_key, google_key
 def process_listings():
     logging.info("Starting listings processing")
     config = load_config()
-    crawler = OtodomCrawler(config.search, headless=config.headless)
+    crawler = OtodomCrawler(
+        config.search, headless=config.headless, base_url=config.base_url
+    )
     openai_key = os.getenv("OPENAI_API_KEY")
     google_key = os.getenv("GOOGLE_API_KEY")
     telegram_token = os.getenv("TELEGRAM_TOKEN")

--- a/otodombot/scraper/crawler.py
+++ b/otodombot/scraper/crawler.py
@@ -10,7 +10,9 @@ from ..config import SearchConditions
 class OtodomCrawler:
     """Crawler for otodom.pl using Playwright."""
 
-    BASE_URL = "https://www.otodom.pl/pl/oferty/sprzedaz/mieszkanie,rynek-wtorny/warszawa"
+    DEFAULT_BASE_URL = (
+        "https://www.otodom.pl/pl/oferty/sprzedaz/mieszkanie,rynek-wtorny/warszawa"
+    )
     USER_AGENT = (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
         "AppleWebKit/537.36 (KHTML, like Gecko) "
@@ -22,11 +24,13 @@ class OtodomCrawler:
         search: SearchConditions | None = None,
         headless: bool = True,
         wait_timeout: int = 15000,
+        base_url: str | None = None,
     ):
         self.search = search or SearchConditions()
         self.headless = headless
         # Maximum time to wait for page elements to load, in milliseconds.
         self.wait_timeout = wait_timeout
+        self.base_url = base_url or self.DEFAULT_BASE_URL
 
     def accept_cookies(self, page) -> None:
         """Attempt to accept cookie banners if present."""
@@ -65,8 +69,6 @@ class OtodomCrawler:
                     enum_values.append(room_map.get(r, str(r)))
             rooms_param = urllib.parse.quote(f"[{','.join(enum_values)}]")
             params.append(f"roomsNumber={rooms_param}")
-        if self.search.market:
-            params.append(f"market={self.search.market.value}")
         if self.search.min_area:
             params.append(f"areaMin={self.search.min_area}")
         sort = sort_by.upper() if sort_by else "DEFAULT"
@@ -75,7 +77,7 @@ class OtodomCrawler:
         else:
             params.append("by=DEFAULT&direction=DESC")
         query = "&".join(params)
-        url = self.BASE_URL + ("?" + query if query else "")
+        url = self.base_url + ("?" + query if query else "")
         logging.debug("Built search URL: %s", url)
         return url
 


### PR DESCRIPTION
## Summary
- move hardcoded BASE_URL into configuration
- drop `market` search setting
- update crawler and scheduler to use `base_url`
- update example config and README

## Testing
- `python -m py_compile otodombot/config.py otodombot/scraper/crawler.py otodombot/scheduler/tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_6856778b4344832eac74c0bbb0ee9053