### PR TITLE
Clarify how to serve frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,17 @@ Start it with:
 python -m otodombot.backend
 ```
 
-Then open `frontend/index.html` in a browser. It fetches data from the API and
-shows the listings on an OpenStreetMap-based map using Leaflet. Popups include
-calculated travel times to your configured points of interest.
+To avoid browser CORS restrictions, serve the static files via a local web
+server instead of opening the HTML file directly. From the `frontend` folder run
+
+```bash
+python -m http.server 8081
+```
+
+and open [http://localhost:8081](http://localhost:8081) in your browser. The
+page fetches data from the API and shows the listings on an OpenStreetMap based
+map using Leaflet. Popups include calculated travel times to your configured
+points of interest.
 
 ### Deploying on Raspberry Pi
 


### PR DESCRIPTION
## Summary
- document that the static frontend should be served via a local web server to avoid browser CORS restrictions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68567e28ba8c832e8642afe68dc9fdc2