### PR TITLE
Serve frontend from backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ Start it with:
 python -m otodombot.backend
 ```
 
-Then open `frontend/index.html` in a browser. It fetches data from the API and
-shows the listings on an OpenStreetMap-based map using Leaflet. Popups include
-calculated travel times to your configured points of interest.
+Open [http://localhost:8000](http://localhost:8000) in your browser. The
+backend now also serves the static map UI so there's no need for a separate web
+server. The page fetches data from the API and shows the listings on an
+OpenStreetMap based map using Leaflet. Popups include calculated travel times to
+your configured points of interest.
 
 ### Deploying on Raspberry Pi
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -124,7 +124,7 @@ function renderList(dest) {
   });
 }
 
-fetch('http://localhost:8000/listings')
+fetch('/listings')
   .then(r => r.json())
   .then(listings => {
     listingsData = listings;

--- a/otodombot/backend.py
+++ b/otodombot/backend.py
@@ -1,5 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from pathlib import Path
 import logging
 import uvicorn
 
@@ -65,6 +67,10 @@ def get_listing(listing_id: int):
         "url": listing.url,
         "commutes": {c.destination: c.minutes for c in listing.commutes},
     }
+
+# Serve static frontend
+frontend_dir = Path(__file__).resolve().parent.parent / "frontend"
+app.mount("/", StaticFiles(directory=frontend_dir, html=True), name="frontend")
 
 def main():
     logging.basicConfig(


### PR DESCRIPTION
## Summary
- make FastAPI backend serve the static frontend
- load listings with a relative URL
- document that the UI is available at http://localhost:8000

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68567e28ba8c832e8642afe68dc9fdc2