### PR TITLE
Restore photo parsing and telegram sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The `sorts` option defines which sorting modes to fetch (e.g. `"DEFAULT"` or `"L
 `commute` config defines destinations for public transit time estimation. The bot will
 calculate travel times from each listing to these addresses for the specified day and time.
 If the times to all points do not exceed the optional `thresholds` values (in minutes),
-the bot sends the listing details to Telegram.
+the bot sends the listing details and photos to Telegram.
 
 ### Environment variables
 

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -44,6 +44,7 @@ def process_single_listing(url, crawler, session, config, openai_key, google_key
         title = crawler.parse_title(html)
         description = crawler.parse_description(html)
         address = ''
+        photos = crawler.parse_photos(html)
         if openai_key:
             address = extract_address(
                 description=description,
@@ -157,6 +158,7 @@ def process_single_listing(url, crawler, session, config, openai_key, google_key
                         token=telegram_token,
                         chat_id=telegram_chat_ids,
                         text="\n".join(text_lines),
+                        photos=photos[:3],
                     )
     except Exception as e:
         logging.error(f"Error processing listing {url}: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- parse photos again when scraping listings
- include a few photos when sending Telegram notifications
- update README about photo sending

## Testing
- `python -m py_compile otodombot/scheduler/tasks.py otodombot/notifications/telegram_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68569e9180a4832e80ca9a84d377ba4e