### PR TITLE
Add max_pages config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Search conditions and crawler settings can be customized via `config.json` in th
   "base_url": "https://www.otodom.pl/pl/oferty/sprzedaz/mieszkanie,rynek-wtorny/warszawa",
   "headless": true,
   "reparse_after_days": 7,
+  "max_pages": 5,
   "commute": {
     "pois": ["Central Station", "Main Office"],
     "day": "Tuesday",
@@ -63,6 +64,7 @@ Search conditions and crawler settings can be customized via `config.json` in th
 
 The `headless` flag controls whether Playwright runs the browser without a visible window.
 `reparse_after_days` specifies how long to wait before revisiting the same listing URL.
+`max_pages` determines how many result pages are crawled for each sorting mode.
 The `sorts` option defines which sorting modes to fetch (e.g. `"DEFAULT"` or `"LATEST"`). Listings are collected for each specified mode in one session.
 `commute` config defines destinations for public transit time estimation. The bot will
 calculate travel times from each listing to these addresses for the specified day and time.

--- a/config.json
+++ b/config.json
@@ -14,6 +14,7 @@
   "base_url": "https://www.otodom.pl/pl/oferty/sprzedaz/mieszkanie,rynek-wtorny/warszawa",
   "headless": true,
   "reparse_after_days": 10,
+  "max_pages": 5,
   "commute": {
     "pois": [
       "Warsaw Spire",

--- a/otodombot/config.py
+++ b/otodombot/config.py
@@ -29,6 +29,7 @@ class Config:
     base_url: str = DEFAULT_BASE_URL
     commute: CommuteSettings = field(default_factory=CommuteSettings)
     reparse_after_days: int = 7
+    max_pages: int = 5
 
 
 def load_config(path: str | Path = "config.json") -> Config:
@@ -41,6 +42,7 @@ def load_config(path: str | Path = "config.json") -> Config:
     headless = data.get("headless", True)
     base_url = data.get("base_url", DEFAULT_BASE_URL)
     reparse_after_days = int(data.get("reparse_after_days", 7))
+    max_pages = int(data.get("max_pages", 5))
     commute_data = data.get("commute", {})
 
     rooms_value = search.get("rooms")
@@ -85,4 +87,5 @@ def load_config(path: str | Path = "config.json") -> Config:
         base_url=base_url,
         commute=commute,
         reparse_after_days=reparse_after_days,
+        max_pages=max_pages,
     )

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -186,7 +186,7 @@ def process_listings():
     fetched: list[str] = []
     for sort in config.search.sorts:
         logging.info("Fetching listings using sort %s", sort)
-        fetched.extend(crawler.fetch_listings(max_pages=5, sort_by=sort))
+        fetched.extend(crawler.fetch_listings(max_pages=config.max_pages, sort_by=sort))
     links = fetched
     links = list(dict.fromkeys(links))
     logging.info("Processing %d links", len(links))


### PR DESCRIPTION
## Summary
- add `max_pages` option to configuration
- use the value when crawling listings
- document new setting in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b01b92638832e80379153261f35fc