### PR TITLE
Add floor parsing and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Skeleton project for parsing [otodom.pl](https://www.otodom.pl) and notifying ab
 - `scheduler/` – APScheduler based periodic tasks.
 - Each listing stores its current price directly.
 - Listing ID is parsed from the listing page and stored for reference.
+- Floor information is parsed when available and stored.
 
 ## Usage
 
@@ -44,7 +45,8 @@ Search conditions and crawler settings can be customized via `config.json` in th
     "max_price": 1000000,
     "rooms": [2, 3],
     "min_area": 40,
-    "sorts": ["DEFAULT", "LATEST"]
+    "sorts": ["DEFAULT", "LATEST"],
+    "ignore_floors": ["parter"]
   },
   "base_url": "https://www.otodom.pl/pl/oferty/sprzedaz/mieszkanie,rynek-wtorny/warszawa",
   "headless": true,
@@ -66,6 +68,7 @@ The `headless` flag controls whether Playwright runs the browser without a visib
 `reparse_after_days` specifies how long to wait before revisiting the same listing URL.
 `max_pages` determines how many result pages are crawled for each sorting mode.
 The `sorts` option defines which sorting modes to fetch (e.g. `"DEFAULT"` or `"LATEST"`). Listings are collected for each specified mode in one session.
+Use `ignore_floors` to skip listings with unwanted floor values (e.g. `"parter"`).
 `commute` config defines destinations for public transit time estimation. The bot will
 calculate travel times from each listing to these addresses for the specified day and time.
 If the times to all points do not exceed the optional `thresholds` values (in minutes),

--- a/otodombot/backend.py
+++ b/otodombot/backend.py
@@ -33,6 +33,7 @@ def get_listings():
             {
                 "id": l.id,
                 "title": l.title,
+                "floor": l.floor,
                 "lat": l.lat,
                 "lng": l.lng,
                 "price": l.price,
@@ -58,6 +59,7 @@ def get_listing(listing_id: int):
         "title": listing.title,
         "description": listing.description,
         "location": listing.location,
+        "floor": listing.floor,
         "price": listing.price,
         "lat": listing.lat,
         "lng": listing.lng,

--- a/otodombot/config.py
+++ b/otodombot/config.py
@@ -13,6 +13,7 @@ class SearchConditions:
     min_area: Optional[int] = None
     sorts: List[str] = field(default_factory=lambda: ["DEFAULT"])
     build_year_min: Optional[int] = None
+    ignore_floors: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -67,6 +68,14 @@ def load_config(path: str | Path = "config.json") -> Config:
         thresholds={k: int(v) for k, v in commute_data.get("thresholds", {}).items() if isinstance(v, (int, str)) and str(v).isdigit()},
     )
 
+    ignore_floors_value = search.get("ignore_floors", [])
+    if isinstance(ignore_floors_value, list):
+        ignore_floors = [str(f).lower() for f in ignore_floors_value]
+    elif ignore_floors_value:
+        ignore_floors = [str(ignore_floors_value).lower()]
+    else:
+        ignore_floors = []
+
     sorts_value = search.get("sorts", ["DEFAULT"])
     if isinstance(sorts_value, list):
         sorts = [str(s).upper() for s in sorts_value if isinstance(s, (str, int))]
@@ -84,6 +93,7 @@ def load_config(path: str | Path = "config.json") -> Config:
             min_area=search.get("min_area"),
             sorts=sorts,
             build_year_min=search.get("build_year_min"),
+            ignore_floors=ignore_floors,
         ),
         headless=headless,
         base_url=base_url,

--- a/otodombot/db/database.py
+++ b/otodombot/db/database.py
@@ -11,3 +11,9 @@ SessionLocal = sessionmaker(bind=engine)
 def init_db():
     logging.debug("Initializing database schema")
     Base.metadata.create_all(bind=engine)
+    # add new columns on existing databases if missing
+    with engine.begin() as conn:
+        try:
+            conn.execute("ALTER TABLE listings ADD COLUMN floor TEXT")
+        except Exception:
+            pass

--- a/otodombot/db/models.py
+++ b/otodombot/db/models.py
@@ -14,6 +14,7 @@ class Listing(Base):
     title = Column(String)
     description = Column(String)
     location = Column(String)
+    floor = Column(String)
     price = Column(Integer)
     lat = Column(Float)
     lng = Column(Float)

--- a/otodombot/scheduler/tasks.py
+++ b/otodombot/scheduler/tasks.py
@@ -40,6 +40,10 @@ def process_single_listing(url, crawler, session, config, openai_key, google_key
             logging.info("Skipping %s due to missing price", url)
             return
         external_id = crawler.parse_listing_id(html)
+        floor = crawler.parse_floor(html)
+        if floor and config.search.ignore_floors and floor.lower() in config.search.ignore_floors:
+            logging.info("Skipping %s due to floor %s", url, floor)
+            return
         is_new = False
         title = crawler.parse_title(html)
         description = crawler.parse_description(html)
@@ -65,6 +69,7 @@ def process_single_listing(url, crawler, session, config, openai_key, google_key
             setattr(listing, 'title', title)
             setattr(listing, 'description', description)
             setattr(listing, 'location', address)
+            setattr(listing, 'floor', floor)
             setattr(listing, 'price', price)
             setattr(listing, 'last_parsed', datetime.utcnow())
             session.commit()
@@ -85,6 +90,7 @@ def process_single_listing(url, crawler, session, config, openai_key, google_key
                 title=title,
                 description=description,
                 location=address,
+                floor=floor,
                 price=price,
                 notes="",
                 is_good=True,

--- a/otodombot/scraper/crawler.py
+++ b/otodombot/scraper/crawler.py
@@ -248,6 +248,16 @@ class OtodomCrawler:
                     return text
         return ""
 
+    def parse_floor(self, html: str) -> Optional[str]:
+        """Extract floor information from the listing HTML."""
+        pattern = r"Pi\u0119tro[^<]*</p>\s*<p[^>]*>([^<]+)"
+        m = re.search(pattern, html, re.IGNORECASE)
+        if m:
+            floor = m.group(1).strip()
+            logging.debug("Parsed floor: %s", floor)
+            return floor
+        return None
+
     def parse_photos(self, html: str) -> List[str]:
         """Extract photo URLs from HTML."""
         urls: list[str] = []


### PR DESCRIPTION
## Summary
- parse floor information in crawler
- store floor in database and include in API responses
- skip listings with ignore_floors config
- handle DB schema upgrade for floor column
- document new config option and feature in README

## Testing
- `python -m compileall -q otodombot`

------
https://chatgpt.com/codex/tasks/task_e_6860f85e85c4832ea52ce72daaa8e933