### PR TITLE
Fix floor parsing with BeautifulSoup

### DIFF
--- a/otodombot/scraper/crawler.py
+++ b/otodombot/scraper/crawler.py
@@ -250,12 +250,18 @@ class OtodomCrawler:
 
     def parse_floor(self, html: str) -> Optional[str]:
         """Extract floor information from the listing HTML."""
-        pattern = r"Pi\u0119tro[^<]*</p>\s*<p[^>]*>([^<]+)"
-        m = re.search(pattern, html, re.IGNORECASE)
-        if m:
-            floor = m.group(1).strip()
-            logging.debug("Parsed floor: %s", floor)
-            return floor
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        for p in soup.find_all("p"):
+            text = p.get_text(strip=True).lower()
+            if text.startswith("piętro"):
+                next_p = p.find_next_sibling("p")
+                if next_p:
+                    floor_text = next_p.get_text(strip=True)
+                    if floor_text:
+                        logging.debug("Parsed floor: %s", floor_text)
+                        return floor_text
         return None
 
     def parse_photos(self, html: str) -> List[str]:

--- a/tests/test_crawler.py
+++ b/tests/test_crawler.py
@@ -1,0 +1,25 @@
+import pytest
+from otodombot.scraper.crawler import OtodomCrawler
+
+
+def test_parse_floor_basic():
+    html = '<div><p>Piętro:</p><p>1/4</p></div>'
+    crawler = OtodomCrawler()
+    assert crawler.parse_floor(html) == '1/4'
+
+
+def test_parse_floor_complex():
+    html = (
+        '<div data-sentry-element="ItemGridContainer">'
+        '<p class="esen0m92 css-1airkmu">Piętro:</p>'
+        '<p class="esen0m92 css-1airkmu">5/5</p>'
+        '</div>'
+    )
+    crawler = OtodomCrawler()
+    assert crawler.parse_floor(html) == '5/5'
+
+
+def test_parse_floor_with_span():
+    html = '<div><p>Piętro:</p><p><span>1</span>/4</p></div>'
+    crawler = OtodomCrawler()
+    assert crawler.parse_floor(html) == '1/4'


### PR DESCRIPTION
## Summary
- parse floor using BeautifulSoup instead of regex
- add regression tests for floor parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686177b18ee0832ea1247a9caf0c2ac5